### PR TITLE
Validate processed file registration input lengths

### DIFF
--- a/lib/core/services/firebase_service.dart
+++ b/lib/core/services/firebase_service.dart
@@ -116,6 +116,16 @@ class FirebaseService {
     List<String> fileHashes,
     List<String> fileNames,
   ) async {
+    if (fileHashes.length != fileNames.length) {
+      debugPrint(
+        'registerProcessedFiles: fileHashes length (${fileHashes.length}) '
+        'does not match fileNames length (${fileNames.length}).',
+      );
+      throw ArgumentError(
+        'fileHashes and fileNames must have the same length',
+      );
+    }
+
     final batch = _db.batch();
     for (int i = 0; i < fileHashes.length; i++) {
       final docRef = _processedFilesCollection.doc(fileHashes[i]);

--- a/test/firebase_service_test.dart
+++ b/test/firebase_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:etl_tamizajes_app/core/services/firebase_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Firebase.initializeApp(
+      options: const FirebaseOptions(
+        apiKey: 'test',
+        appId: '1:1234567890:android:abc123def456',
+        messagingSenderId: '1234567890',
+        projectId: 'test',
+      ),
+    );
+  });
+
+  test('throws if list lengths differ', () {
+    final service = FirebaseService();
+
+    expect(
+      () => service.registerProcessedFiles(['hash1'], ['name1', 'name2']),
+      throwsArgumentError,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- ensure `registerProcessedFiles` checks for mismatched `fileHashes` and `fileNames`
- add unit test covering differing list lengths

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689661af84ac8328b9b0b8f208f82ae4