### PR TITLE
feat: add basic internationalization

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_es.arb
+output-localization-file: app_localizations.dart

--- a/lib/features/auth/login_view.dart
+++ b/lib/features/auth/login_view.dart
@@ -1,6 +1,7 @@
 // lib/features/auth/login_view.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:etl_tamizajes_app/features/auth/auth_provider.dart';
 
@@ -71,10 +72,10 @@ class _LoginViewState extends State<LoginView> {
                       ),
                       const SizedBox(width: 16),
                       Expanded(
-                        child: const Text(
-                          'Red de Salud\ndel Oriente',
+                        child: Text(
+                          AppLocalizations.of(context)!.networkTitle,
                           textAlign: TextAlign.start,
-                          style: TextStyle(
+                          style: const TextStyle(
                             fontFamily: 'Inter',
                             fontSize: 28,
                             fontWeight: FontWeight.bold,
@@ -109,18 +110,19 @@ class _LoginViewState extends State<LoginView> {
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
-                          'Bienvenido',
-                          style: TextStyle(
+                        Text(
+                          AppLocalizations.of(context)!.welcome,
+                          style: const TextStyle(
                             fontSize: 26,
                             fontWeight: FontWeight.bold,
                             color: Colors.black87,
                           ),
                         ),
                         const SizedBox(height: 8),
-                        const Text(
-                          'Inicia sesión para acceder a la plataforma.',
-                          style: TextStyle(fontSize: 16, color: Colors.black54),
+                        Text(
+                          AppLocalizations.of(context)!.loginPrompt,
+                          style:
+                              const TextStyle(fontSize: 16, color: Colors.black54),
                         ),
                         const SizedBox(height: 32),
 
@@ -128,7 +130,7 @@ class _LoginViewState extends State<LoginView> {
                         TextFormField(
                           controller: _emailController,
                           decoration: InputDecoration(
-                            labelText: 'Correo Electrónico',
+                            labelText: AppLocalizations.of(context)!.emailLabel,
                             prefixIcon: const Icon(Icons.email_outlined),
                             filled: true,
                             fillColor: Colors.grey.shade50,
@@ -150,7 +152,8 @@ class _LoginViewState extends State<LoginView> {
                             if (value == null ||
                                 value.isEmpty ||
                                 !value.contains('@')) {
-                              return 'Por favor, introduce un correo válido.';
+                              return AppLocalizations.of(context)!
+                                  .invalidEmailError;
                             }
                             return null;
                           },
@@ -162,7 +165,7 @@ class _LoginViewState extends State<LoginView> {
                           controller: _passwordController,
                           obscureText: !_isPasswordVisible,
                           decoration: InputDecoration(
-                            labelText: 'Contraseña',
+                            labelText: AppLocalizations.of(context)!.passwordLabel,
                             prefixIcon: const Icon(Icons.lock_outline),
                             filled: true,
                             fillColor: Colors.grey.shade50,
@@ -193,7 +196,8 @@ class _LoginViewState extends State<LoginView> {
                           ),
                           validator: (value) {
                             if (value == null || value.isEmpty) {
-                              return 'Por favor, introduce tu contraseña.';
+                              return AppLocalizations.of(context)!
+                                  .emptyPasswordError;
                             }
                             return null;
                           },
@@ -221,9 +225,9 @@ class _LoginViewState extends State<LoginView> {
                                 ),
                                 elevation: 2,
                               ),
-                              child: const Text(
-                                'Iniciar Sesión',
-                                style: TextStyle(
+                              child: Text(
+                                AppLocalizations.of(context)!.loginButton,
+                                style: const TextStyle(
                                   fontSize: 18,
                                   fontWeight: FontWeight.bold,
                                   color: Colors.white,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,19 @@
+{
+  "@@locale": "en",
+  "appTitle": "ETL Screenings",
+  "networkTitle": "Eastern Health\nNetwork",
+  "welcome": "Welcome",
+  "loginPrompt": "Sign in to access the platform.",
+  "emailLabel": "Email",
+  "invalidEmailError": "Please enter a valid email.",
+  "passwordLabel": "Password",
+  "emptyPasswordError": "Please enter your password.",
+  "loginButton": "Log In",
+  "upload": "Upload",
+  "records": "Records",
+  "dashboard": "Dashboard",
+  "users": "Users",
+  "master": "Master",
+  "logout": "Log Out",
+  "userPlaceholder": "User"
+}

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,0 +1,19 @@
+{
+  "@@locale": "es",
+  "appTitle": "ETL Tamizajes",
+  "networkTitle": "Red de Salud\ndel Oriente",
+  "welcome": "Bienvenido",
+  "loginPrompt": "Inicia sesión para acceder a la plataforma.",
+  "emailLabel": "Correo electrónico",
+  "invalidEmailError": "Por favor, introduce un correo válido.",
+  "passwordLabel": "Contraseña",
+  "emptyPasswordError": "Por favor, introduce tu contraseña.",
+  "loginButton": "Iniciar Sesión",
+  "upload": "Cargar",
+  "records": "Registros",
+  "dashboard": "Dashboard",
+  "users": "Usuarios",
+  "master": "Maestro",
+  "logout": "Cerrar Sesión",
+  "userPlaceholder": "Usuario"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:etl_tamizajes_app/firebase_options.dart';
@@ -67,8 +68,11 @@ class MyApp extends StatelessWidget {
           final router = AppRouter(authProvider).router;
 
           return MaterialApp.router(
-            title: 'ETL Tamizajes',
             debugShowCheckedModeBanner: false,
+            onGenerateTitle: (context) =>
+                AppLocalizations.of(context)!.appTitle,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             theme: ThemeData(
               primarySwatch: Colors.blue,
               useMaterial3: true,

--- a/lib/main_scaffold.dart
+++ b/lib/main_scaffold.dart
@@ -1,6 +1,7 @@
 // lib/main_scaffold.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:etl_tamizajes_app/features/auth/auth_provider.dart';
@@ -50,7 +51,7 @@ class MainScaffold extends StatelessWidget {
       return Scaffold(
         body: child,
         appBar: AppBar(
-          title: const Text('ETL Tamizajes'),
+          title: Text(AppLocalizations.of(context)!.appTitle),
           backgroundColor: Colors.white,
           elevation: 1,
         ),
@@ -85,7 +86,7 @@ class _AppNavigationRail extends StatelessWidget {
         (context.findAncestorWidgetOfExactType<MainScaffold>())!
             ._onDestinationSelected;
 
-    final destinations = _buildDestinations(authProvider);
+    final destinations = _buildDestinations(authProvider, context);
 
     return NavigationRail(
       selectedIndex: selectedIndex < destinations.length ? selectedIndex : 0,
@@ -129,7 +130,7 @@ class _AppDrawer extends StatelessWidget {
         (context.findAncestorWidgetOfExactType<MainScaffold>())!
             ._onDestinationSelected;
 
-    final destinations = _buildDestinations(authProvider);
+    final destinations = _buildDestinations(authProvider, context);
 
     return Drawer(
       child: Column(
@@ -161,32 +162,34 @@ class _AppDrawer extends StatelessWidget {
 
 // --- HELPERS COMPARTIDOS ---
 
-List<NavigationRailDestination> _buildDestinations(AuthProvider authProvider) {
+List<NavigationRailDestination> _buildDestinations(
+    AuthProvider authProvider, BuildContext context) {
+  final l10n = AppLocalizations.of(context)!;
   final allDestinations = [
-    const NavigationRailDestination(
-      icon: Icon(Icons.cloud_upload_outlined),
-      selectedIcon: Icon(Icons.cloud_upload),
-      label: Text('Cargar'),
+    NavigationRailDestination(
+      icon: const Icon(Icons.cloud_upload_outlined),
+      selectedIcon: const Icon(Icons.cloud_upload),
+      label: Text(l10n.upload),
     ),
-    const NavigationRailDestination(
-      icon: Icon(Icons.folder_copy_outlined),
-      selectedIcon: Icon(Icons.folder_copy),
-      label: Text('Registros'),
+    NavigationRailDestination(
+      icon: const Icon(Icons.folder_copy_outlined),
+      selectedIcon: const Icon(Icons.folder_copy),
+      label: Text(l10n.records),
     ),
-    const NavigationRailDestination(
-      icon: Icon(Icons.dashboard_outlined),
-      selectedIcon: Icon(Icons.dashboard),
-      label: Text('Dashboard'),
+    NavigationRailDestination(
+      icon: const Icon(Icons.dashboard_outlined),
+      selectedIcon: const Icon(Icons.dashboard),
+      label: Text(l10n.dashboard),
     ),
-    const NavigationRailDestination(
-      icon: Icon(Icons.people_outline),
-      selectedIcon: Icon(Icons.people),
-      label: Text('Usuarios'),
+    NavigationRailDestination(
+      icon: const Icon(Icons.people_outline),
+      selectedIcon: const Icon(Icons.people),
+      label: Text(l10n.users),
     ),
-    const NavigationRailDestination(
-      icon: Icon(Icons.storage_outlined),
-      selectedIcon: Icon(Icons.storage),
-      label: Text('Maestro'),
+    NavigationRailDestination(
+      icon: const Icon(Icons.storage_outlined),
+      selectedIcon: const Icon(Icons.storage),
+      label: Text(l10n.master),
     ),
   ];
 
@@ -226,7 +229,7 @@ Widget _buildUserHeader(BuildContext context, AuthProvider authProvider) {
         ),
         const SizedBox(height: 12),
         Text(
-          user?.displayName ?? 'Usuario',
+          user?.displayName ?? AppLocalizations.of(context)!.userPlaceholder,
           style: const TextStyle(
             color: Colors.white,
             fontSize: 18,
@@ -245,6 +248,7 @@ Widget _buildUserHeader(BuildContext context, AuthProvider authProvider) {
 }
 
 Widget _buildLogoutButton(BuildContext context, {bool isDrawer = false}) {
+  final l10n = AppLocalizations.of(context)!;
   final content = Row(
     mainAxisAlignment: isDrawer
         ? MainAxisAlignment.start
@@ -253,9 +257,9 @@ Widget _buildLogoutButton(BuildContext context, {bool isDrawer = false}) {
       const Icon(Icons.logout, color: Colors.redAccent),
       if (isDrawer) ...[
         const SizedBox(width: 16),
-        const Text(
-          'Cerrar Sesión',
-          style: TextStyle(
+        Text(
+          l10n.logout,
+          style: const TextStyle(
             color: Colors.redAccent,
             fontWeight: FontWeight.bold,
           ),
@@ -277,6 +281,6 @@ Widget _buildLogoutButton(BuildContext context, {bool isDrawer = false}) {
   return IconButton(
     icon: content,
     onPressed: () => context.read<AuthProvider>().signOut(),
-    tooltip: 'Cerrar Sesión',
+    tooltip: l10n.logout,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # Firebase
   firebase_core: ^4.0.0
@@ -37,9 +39,9 @@ dependencies:
 
   # Utilidades
   collection: ^1.18.0
-  intl: ^0.19.0 # <-- Se ajusta a una versión compatible
   google_fonts: ^6.2.1
   geolocator: ^14.0.2
+  intl: ^0.19.0 # <-- Se ajusta a una versión compatible
 
 dev_dependencies:
   flutter_test:
@@ -53,5 +55,6 @@ dependency_overrides:
 
 flutter:
   uses-material-design: true
+  generate: true
   assets:
     - assets/images/


### PR DESCRIPTION
## Summary
- configure Flutter internationalization with `flutter_localizations` and ARB files
- move login and navigation texts into translation resources
- replace hardcoded strings with `AppLocalizations`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896729909b883288297ace7b514afc2